### PR TITLE
Fix Makefile issues, erlang-rfc4627 repo URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ebin
+lib/erlang-rfc4627

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 all: compile
 
 compile:
+	mkdir -p ebin
 	@erl -make
 
 clean:

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -2,9 +2,9 @@ all: getjsonlib compilejsonlib
 
 getjsonlib:
 	if [ -d "erlang-rfc4627" ]; then \
-		cd erlang-rfc4627 ; hg update ;\
+		cd erlang-rfc4627 ; git pull ;\
 	else \
-		hg clone http://hg.opensource.lshift.net/erlang-rfc4627/ ;\
+		git clone https://github.com/tonyg/erlang-rfc4627.git ;\
 	fi
 
 compilejsonlib:


### PR DESCRIPTION
- Mercurial repo for tonyg/erlang-rfc4627 is no longer available; updated to use Git and a GitHub clone URL instead

- The default `make` target would fail if the `ebin` directory didn't exist; `Makefile` now creates this directory first (and `.gitignore` excludes it from version control)